### PR TITLE
Hour for syslog_date_time should be 24-hour not 12

### DIFF
--- a/duo_log_grabber.py
+++ b/duo_log_grabber.py
@@ -153,7 +153,7 @@ if __name__ == "__main__":
         mintime = utc_date - DELTA
 
         syslog_date = datetime.now()
-        syslog_date_time = syslog_date.strftime("%b %d %I:%M:%S")
+        syslog_date_time = syslog_date.strftime("%b %d %H:%M:%S")
         syslog_header = ' '.join([syslog_date_time, HOSTNAME])
         
         l = UDPSyslogEmitter(address=(SYSLOG_SERVER, SYSLOG_PORT))


### PR DESCRIPTION
The `%I` directive is for 12 hour representation of time, the syslog
header as specified in RFC 5424 refers to RFC 3339 for the timestamp
which specify hour should be in the 24-hour format.

http://tools.ietf.org/html/rfc5424#section-6.2.3 - Syslog Timestamp
http://tools.ietf.org/html/rfc3339#section-5.6 - Date/Time Format

Replaced it with the `%H` directive is the 24-hour meaning,
corresponding table in the link below -

https://docs.python.org/2/library/time.html#time.strftime
